### PR TITLE
Update cicd.ssl.j2

### DIFF
--- a/workdir/ansible/playbooks/nginx_workshop_gw/conf.d/cicd.ssl.j2
+++ b/workdir/ansible/playbooks/nginx_workshop_gw/conf.d/cicd.ssl.j2
@@ -58,6 +58,9 @@ server {
     location / {
       proxy_pass http://jenkins;
       proxy_http_version 1.1;
+      sub_filter 'http://git.{{ wsid }}.{{ domain }}:3000/'  'https://git.{{ wsid }}.{{ domain }}/';
+      sub_filter_once off;
+      proxy_set_header Accept-Encoding "";
       proxy_set_header Connection "";
       proxy_set_header Host      $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
To get access to Gitea commit detail, Jenkins generate the URL in http://git:3000
I propose to use sub_filter module to rewrite this to the secure https connector